### PR TITLE
fix: enable proxy_ssl_server_name for userinfo endpoint

### DIFF
--- a/oidc_nginx_server.conf
+++ b/oidc_nginx_server.conf
@@ -109,6 +109,7 @@
         auth_jwt "" token=$id_token;
         auth_jwt_key_request /_jwks_uri;        # Enable when using URL
 
+        proxy_ssl_server_name on; # For SNI to the IdP
         proxy_set_header Authorization "Bearer $access_token";
         proxy_pass       $oidc_userinfo_endpoint;
         access_log /var/log/nginx/access.log oidc_jwt;


### PR DESCRIPTION
- Enable `proxy_ssl_server_name` directive before `proxy_pass $oidc_userinfo_endpoint`.
- So `/userinfo` works well between NGINX Plus OIDC and Ping Identity.
- It works with other identity providers (Amazon Cognito, Auth0, Azure AD, Keycloak, Okta, OneLogin).